### PR TITLE
Create Let Travel WordPress theme

### DIFF
--- a/wp-content/themes/let-travel/README.md
+++ b/wp-content/themes/let-travel/README.md
@@ -1,0 +1,25 @@
+# Let Travel WordPress Theme
+
+A WordPress theme inspired by the Let Travel Webflow landing page. It recreates the hero, destination highlights, features, sustainability focus, testimonials, blog preview, and call-to-action sections as seen on the original design.
+
+## Installation
+
+1. Copy the `let-travel` folder into your WordPress installation under `wp-content/themes/`.
+2. Log into the WordPress admin dashboard and activate the **Let Travel** theme.
+3. Assign menus to the **Primary Menu** and **Footer Menu** locations from **Appearance → Menus**.
+4. Create a page and set it as the static front page via **Settings → Reading**.
+5. Customize the call-to-action messaging via **Appearance → Customize → Call To Action**.
+
+## Features
+
+- Responsive layout with typography inspired by the original Webflow site.
+- Hero section with stats, featured destinations, testimonials, and CTA blocks.
+- Blog section that automatically shows the three latest posts.
+- Footer widget area to connect newsletter forms or other widgets.
+- Smooth scrolling and sticky header behavior.
+
+## Development
+
+- Styles are located in `style.css` and `assets/css/main.css`.
+- JavaScript enhancements live in `assets/js/main.js`.
+- Template structure follows WordPress standards for easy customization.

--- a/wp-content/themes/let-travel/assets/css/main.css
+++ b/wp-content/themes/let-travel/assets/css/main.css
@@ -1,0 +1,47 @@
+.site-header.is-scrolled {
+  box-shadow: 0 12px 25px rgba(15, 23, 42, 0.08);
+  background: rgba(255, 255, 255, 0.95);
+}
+
+.menu-items,
+.footer-menu {
+  list-style: none;
+  display: flex;
+  gap: 1.5rem;
+  margin: 0;
+  padding: 0;
+}
+
+.footer-menu {
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.newsletter {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.newsletter input[type='email'] {
+  padding: 0.85rem 1.1rem;
+  border-radius: 999px;
+  border: none;
+  font-size: 0.95rem;
+}
+
+.entry-content {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.entry-content > *:first-child {
+  margin-top: 0;
+}
+
+.entry-content a {
+  color: var(--color-primary);
+}
+
+.entry-title {
+  font-family: var(--font-display);
+}

--- a/wp-content/themes/let-travel/assets/js/main.js
+++ b/wp-content/themes/let-travel/assets/js/main.js
@@ -1,0 +1,39 @@
+(function ($) {
+    'use strict';
+
+    const body = $('body');
+
+    // Smooth scroll for anchor links
+    $('a[href*="#"]').not('[href="#"]').on('click', function (event) {
+        if (
+            location.pathname.replace(/^\//, '') === this.pathname.replace(/^\//, '') &&
+            location.hostname === this.hostname
+        ) {
+            let target = $(this.hash);
+            target = target.length ? target : $('[name=' + this.hash.slice(1) + ']');
+            if (target.length) {
+                event.preventDefault();
+                $('html, body').animate(
+                    {
+                        scrollTop: target.offset().top - 80,
+                    },
+                    700
+                );
+            }
+        }
+    });
+
+    // Sticky header shadow toggle
+    const header = $('.site-header');
+    if (header.length) {
+        const toggleHeaderState = () => {
+            if ($(window).scrollTop() > 40) {
+                header.addClass('is-scrolled');
+            } else {
+                header.removeClass('is-scrolled');
+            }
+        };
+        toggleHeaderState();
+        $(window).on('scroll', toggleHeaderState);
+    }
+})(jQuery);

--- a/wp-content/themes/let-travel/footer.php
+++ b/wp-content/themes/let-travel/footer.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Footer template
+ *
+ * @package Let_Travel
+ */
+?>
+    </main><!-- #primary -->
+    <footer class="site-footer">
+        <div class="container">
+            <div class="site-footer__top">
+                <div class="site-footer__brand">
+                    <a class="site-logo" href="<?php echo esc_url( home_url( '/' ) ); ?>">Let Travel</a>
+                    <p><?php esc_html_e( 'Crafting immersive travel experiences to reconnect you with the world.', 'let-travel' ); ?></p>
+                    <div class="site-footer__socials">
+                        <a href="https://www.facebook.com" aria-label="<?php esc_attr_e( 'Facebook', 'let-travel' ); ?>"></a>
+                        <a href="https://www.instagram.com" aria-label="<?php esc_attr_e( 'Instagram', 'let-travel' ); ?>"></a>
+                        <a href="https://www.twitter.com" aria-label="<?php esc_attr_e( 'Twitter', 'let-travel' ); ?>"></a>
+                    </div>
+                </div>
+                <div class="site-footer__menus">
+                    <div>
+                        <h4><?php esc_html_e( 'Company', 'let-travel' ); ?></h4>
+                        <?php
+                        wp_nav_menu(
+                            array(
+                                'theme_location' => 'footer',
+                                'menu_class'     => 'footer-menu',
+                                'container'      => false,
+                                'fallback_cb'    => false,
+                            )
+                        );
+                        ?>
+                    </div>
+                    <div>
+                        <h4><?php esc_html_e( 'Get in touch', 'let-travel' ); ?></h4>
+                        <ul>
+                            <li><a href="mailto:hello@example.com">hello@example.com</a></li>
+                            <li><a href="tel:+123456789">+1 (234) 567-89</a></li>
+                            <li><?php esc_html_e( '21 Adventure Way, San Francisco, CA', 'let-travel' ); ?></li>
+                        </ul>
+                    </div>
+                    <div>
+                        <h4><?php esc_html_e( 'Newsletter', 'let-travel' ); ?></h4>
+                        <?php if ( is_active_sidebar( 'footer-newsletter' ) ) : ?>
+                            <?php dynamic_sidebar( 'footer-newsletter' ); ?>
+                        <?php else : ?>
+                            <form class="newsletter" action="#" method="post">
+                                <label for="newsletter-email" class="screen-reader-text"><?php esc_html_e( 'Email address', 'let-travel' ); ?></label>
+                                <input type="email" id="newsletter-email" name="newsletter-email" placeholder="<?php esc_attr_e( 'Enter your email', 'let-travel' ); ?>" required />
+                                <button class="btn btn--primary" type="submit"><?php esc_html_e( 'Subscribe', 'let-travel' ); ?></button>
+                            </form>
+                        <?php endif; ?>
+                    </div>
+                </div>
+            </div>
+            <div class="site-footer__bottom">
+                <p>&copy; <?php echo esc_html( gmdate( 'Y' ) ); ?> <?php esc_html_e( 'Let Travel. All rights reserved.', 'let-travel' ); ?></p>
+                <p><?php esc_html_e( 'Designed for WordPress using the Let Travel theme.', 'let-travel' ); ?></p>
+            </div>
+        </div>
+    </footer>
+</div><!-- .site-wrapper -->
+<?php wp_footer(); ?>
+</body>
+</html>

--- a/wp-content/themes/let-travel/front-page.php
+++ b/wp-content/themes/let-travel/front-page.php
@@ -1,0 +1,228 @@
+<?php
+/**
+ * Front page template that recreates the Let Travel Webflow layout.
+ *
+ * @package Let_Travel
+ */
+
+global $post;
+
+get_header();
+?>
+<section class="section hero-section">
+    <div class="container hero">
+        <div class="hero__content">
+            <span class="hero__tag"><?php esc_html_e( 'Discover More', 'let-travel' ); ?></span>
+            <h1 class="hero__heading"><?php esc_html_e( 'Open up your world with unforgettable journeys', 'let-travel' ); ?></h1>
+            <p class="hero__copy"><?php esc_html_e( 'Let Travel connects you with curated destinations, expert guides, and immersive experiences designed to make every trip extraordinary.', 'let-travel' ); ?></p>
+            <div class="hero__actions">
+                <a class="btn btn--primary" href="<?php echo esc_url( home_url( '/destinations' ) ); ?>"><?php esc_html_e( 'Explore Destinations', 'let-travel' ); ?></a>
+                <a class="btn btn--ghost" href="<?php echo esc_url( home_url( '/contact' ) ); ?>"><?php esc_html_e( 'Talk to an Expert', 'let-travel' ); ?></a>
+            </div>
+            <div class="hero__meta">
+                <div class="hero__stat">
+                    <span>250+</span>
+                    <small><?php esc_html_e( 'Curated trips designed by our travel experts.', 'let-travel' ); ?></small>
+                </div>
+                <div class="hero__stat">
+                    <span>98%</span>
+                    <small><?php esc_html_e( 'Customer satisfaction rate across the last 24 months.', 'let-travel' ); ?></small>
+                </div>
+            </div>
+        </div>
+        <div class="hero__visual">
+            <img src="https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=900&q=80" alt="Mountains" />
+            <div class="hero__card" role="note">
+                <h4><?php esc_html_e( 'Trending escapes', 'let-travel' ); ?></h4>
+                <ul>
+                    <li><span><?php esc_html_e( 'Bali retreat', 'let-travel' ); ?></span> <span>★ 4.9</span></li>
+                    <li><span><?php esc_html_e( 'Iceland expedition', 'let-travel' ); ?></span> <span>★ 4.8</span></li>
+                    <li><span><?php esc_html_e( 'Peru discovery', 'let-travel' ); ?></span> <span>★ 4.7</span></li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section class="section section--light">
+    <div class="container">
+        <p class="section__subtitle"><?php esc_html_e( 'Destinations', 'let-travel' ); ?></p>
+        <h2 class="section__title"><?php esc_html_e( 'Handpicked adventures across the globe', 'let-travel' ); ?></h2>
+        <p class="section__text"><?php esc_html_e( 'Choose from our most loved destinations and enjoy tailored itineraries that blend local culture, iconic sights, and hidden gems.', 'let-travel' ); ?></p>
+        <div class="destinations">
+            <?php
+            $destination_images = array(
+                'https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1000&q=80' => __( 'Swiss Alps', 'let-travel' ),
+                'https://images.unsplash.com/photo-1470071459604-3b5ec3a7fe05?auto=format&fit=crop&w=1000&q=80' => __( 'Bali, Indonesia', 'let-travel' ),
+                'https://images.unsplash.com/photo-1526772662000-3f88f10405ff?auto=format&fit=crop&w=1000&q=80' => __( 'Kyoto, Japan', 'let-travel' ),
+                'https://images.unsplash.com/photo-1505761671935-60b3a7427bad?auto=format&fit=crop&w=1000&q=80' => __( 'Amalfi Coast, Italy', 'let-travel' ),
+            );
+
+            foreach ( $destination_images as $image_url => $destination_name ) :
+                ?>
+                <article class="destination-card">
+                    <img src="<?php echo esc_url( $image_url ); ?>" alt="<?php echo esc_attr( $destination_name ); ?>" />
+                    <div class="destination-card__label">
+                        <span><?php esc_html_e( 'From', 'let-travel' ); ?> $899</span>
+                        <strong><?php echo esc_html( $destination_name ); ?></strong>
+                    </div>
+                </article>
+                <?php
+            endforeach;
+            ?>
+        </div>
+    </div>
+</section>
+
+<section class="section">
+    <div class="container">
+        <p class="section__subtitle"><?php esc_html_e( 'Why Let Travel', 'let-travel' ); ?></p>
+        <h2 class="section__title"><?php esc_html_e( 'Designing journeys that feel effortless', 'let-travel' ); ?></h2>
+        <div class="features">
+            <article class="feature">
+                <span class="feature__icon">✈️</span>
+                <h3 class="feature__title"><?php esc_html_e( 'Expert travel planners', 'let-travel' ); ?></h3>
+                <p class="feature__text"><?php esc_html_e( 'Our team of specialists craft itineraries around your interests so you can explore confidently.', 'let-travel' ); ?></p>
+            </article>
+            <article class="feature">
+                <span class="feature__icon">🏨</span>
+                <h3 class="feature__title"><?php esc_html_e( 'Curated stays & guides', 'let-travel' ); ?></h3>
+                <p class="feature__text"><?php esc_html_e( 'Stay in boutique hotels and connect with knowledgeable local guides for authentic encounters.', 'let-travel' ); ?></p>
+            </article>
+            <article class="feature">
+                <span class="feature__icon">🧭</span>
+                <h3 class="feature__title"><?php esc_html_e( 'Support at every step', 'let-travel' ); ?></h3>
+                <p class="feature__text"><?php esc_html_e( 'Enjoy 24/7 support, flexible itineraries, and on-the-ground assistance wherever you roam.', 'let-travel' ); ?></p>
+            </article>
+        </div>
+    </div>
+</section>
+
+<section class="section section--overlay">
+    <div class="container">
+        <div class="section__subtitle"><?php esc_html_e( 'Impact', 'let-travel' ); ?></div>
+        <h2 class="section__title"><?php esc_html_e( 'Travel that gives back', 'let-travel' ); ?></h2>
+        <p class="section__text"><?php esc_html_e( 'We partner with local communities and sustainability initiatives to leave every place better than we found it.', 'let-travel' ); ?></p>
+        <div class="stats-grid">
+            <div class="stat-card">
+                <strong>65%</strong>
+                <span><?php esc_html_e( 'Trips featuring eco-certified experiences.', 'let-travel' ); ?></span>
+            </div>
+            <div class="stat-card">
+                <strong>120+</strong>
+                <span><?php esc_html_e( 'Local partners supporting responsible tourism.', 'let-travel' ); ?></span>
+            </div>
+            <div class="stat-card">
+                <strong>35k</strong>
+                <span><?php esc_html_e( 'Trees planted through traveler contributions.', 'let-travel' ); ?></span>
+            </div>
+        </div>
+    </div>
+</section>
+
+<section class="section">
+    <div class="container">
+        <p class="section__subtitle"><?php esc_html_e( 'Stories', 'let-travel' ); ?></p>
+        <h2 class="section__title"><?php esc_html_e( 'Travelers who found their perfect escape', 'let-travel' ); ?></h2>
+        <div class="testimonials">
+            <?php
+            $testimonials = array(
+                array(
+                    'name'  => __( 'Maya Chen', 'let-travel' ),
+                    'role'  => __( 'Solo adventurer', 'let-travel' ),
+                    'quote' => __( 'Let Travel created an itinerary through Peru that felt deeply personal. I never once felt like a tourist.', 'let-travel' ),
+                    'image' => 'https://images.unsplash.com/photo-1544723795-3fb6469f5b39?auto=format&fit=crop&w=300&q=80',
+                ),
+                array(
+                    'name'  => __( 'Aaron Patel', 'let-travel' ),
+                    'role'  => __( 'Honeymoon traveler', 'let-travel' ),
+                    'quote' => __( 'From boutique hotels to private guides, every detail was beyond what we imagined. Truly unforgettable.', 'let-travel' ),
+                    'image' => 'https://images.unsplash.com/photo-1500648767791-00dcc994a43e?auto=format&fit=crop&w=300&q=80',
+                ),
+                array(
+                    'name'  => __( 'Carmen & Diego', 'let-travel' ),
+                    'role'  => __( 'Family explorers', 'let-travel' ),
+                    'quote' => __( 'Traveling with kids can be daunting, but Let Travel made it seamless. The experiences were magical.', 'let-travel' ),
+                    'image' => 'https://images.unsplash.com/photo-1544005313-94ddf0286df2?auto=format&fit=crop&w=300&q=80',
+                ),
+            );
+
+            foreach ( $testimonials as $testimonial ) :
+                ?>
+                <article class="testimonial">
+                    <p class="testimonial__quote">&ldquo;<?php echo esc_html( $testimonial['quote'] ); ?>&rdquo;</p>
+                    <div class="testimonial__meta">
+                        <img src="<?php echo esc_url( $testimonial['image'] ); ?>" alt="<?php echo esc_attr( $testimonial['name'] ); ?>" />
+                        <div>
+                            <div class="testimonial__name"><?php echo esc_html( $testimonial['name'] ); ?></div>
+                            <small><?php echo esc_html( $testimonial['role'] ); ?></small>
+                        </div>
+                    </div>
+                </article>
+                <?php
+            endforeach;
+            ?>
+        </div>
+    </div>
+</section>
+
+<section class="section section--light">
+    <div class="container">
+        <p class="section__subtitle"><?php esc_html_e( 'Latest Articles', 'let-travel' ); ?></p>
+        <h2 class="section__title"><?php esc_html_e( 'Insights from our travel journal', 'let-travel' ); ?></h2>
+        <div class="blog-grid">
+            <?php
+            $blog_query = new WP_Query(
+                array(
+                    'posts_per_page' => 3,
+                    'post_status'    => 'publish',
+                )
+            );
+
+            if ( $blog_query->have_posts() ) :
+                while ( $blog_query->have_posts() ) :
+                    $blog_query->the_post();
+                    ?>
+                    <article class="blog-card">
+                        <?php if ( has_post_thumbnail() ) : ?>
+                            <a href="<?php the_permalink(); ?>" class="blog-card__image"><?php the_post_thumbnail( 'large' ); ?></a>
+                        <?php else : ?>
+                            <a href="<?php the_permalink(); ?>" class="blog-card__image">
+                                <img src="https://images.unsplash.com/photo-1469474968028-56623f02e42e?auto=format&fit=crop&w=900&q=80" alt="<?php the_title_attribute(); ?>" />
+                            </a>
+                        <?php endif; ?>
+                        <div class="blog-card__body">
+                            <div class="blog-card__meta">
+                                <?php let_travel_posted_on(); ?>
+                            </div>
+                            <h3 class="blog-card__title"><a href="<?php the_permalink(); ?>"><?php the_title(); ?></a></h3>
+                            <p><?php echo wp_trim_words( get_the_excerpt(), 18, '…' ); ?></p>
+                            <a class="btn btn--primary" href="<?php the_permalink(); ?>"><?php esc_html_e( 'Read More', 'let-travel' ); ?></a>
+                        </div>
+                    </article>
+                    <?php
+                endwhile;
+                wp_reset_postdata();
+            else :
+                ?>
+                <p><?php esc_html_e( 'No posts yet. Start sharing your travel stories!', 'let-travel' ); ?></p>
+                <?php
+            endif;
+            ?>
+        </div>
+    </div>
+</section>
+
+<section class="section">
+    <div class="container">
+        <div class="cta">
+            <h2 class="cta__title"><?php echo esc_html( get_theme_mod( 'let_travel_cta_title', __( 'Ready for your next adventure?', 'let-travel' ) ) ); ?></h2>
+            <p><?php echo wp_kses_post( get_theme_mod( 'let_travel_cta_description', __( 'Join thousands of travelers exploring the world with Let Travel.', 'let-travel' ) ) ); ?></p>
+            <?php if ( $cta_button_url = get_theme_mod( 'let_travel_cta_button_url', home_url( '/contact' ) ) ) : ?>
+                <a class="btn btn--primary" href="<?php echo esc_url( $cta_button_url ); ?>"><?php echo esc_html( get_theme_mod( 'let_travel_cta_button_text', __( 'Plan a Trip', 'let-travel' ) ) ); ?></a>
+            <?php endif; ?>
+        </div>
+    </div>
+</section>
+<?php
+get_footer();

--- a/wp-content/themes/let-travel/functions.php
+++ b/wp-content/themes/let-travel/functions.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Let Travel theme functions and definitions
+ *
+ * @package Let_Travel
+ */
+
+if ( ! defined( 'LET_TRAVEL_VERSION' ) ) {
+    define( 'LET_TRAVEL_VERSION', '1.0.0' );
+}
+
+if ( ! function_exists( 'let_travel_setup' ) ) {
+    /**
+     * Set up theme defaults and register support for various WordPress features.
+     */
+    function let_travel_setup() {
+        load_theme_textdomain( 'let-travel', get_template_directory() . '/languages' );
+
+        add_theme_support( 'automatic-feed-links' );
+        add_theme_support( 'title-tag' );
+        add_theme_support( 'post-thumbnails' );
+        add_theme_support( 'align-wide' );
+        add_theme_support( 'wp-block-styles' );
+
+        register_nav_menus(
+            array(
+                'primary' => __( 'Primary Menu', 'let-travel' ),
+                'footer'  => __( 'Footer Menu', 'let-travel' ),
+            )
+        );
+
+        add_theme_support(
+            'html5',
+            array(
+                'search-form',
+                'comment-form',
+                'comment-list',
+                'gallery',
+                'caption',
+                'script',
+                'style',
+            )
+        );
+
+        add_theme_support(
+            'custom-logo',
+            array(
+                'height'      => 80,
+                'width'       => 240,
+                'flex-width'  => true,
+                'flex-height' => true,
+            )
+        );
+    }
+}
+add_action( 'after_setup_theme', 'let_travel_setup' );
+
+/**
+ * Enqueue scripts and styles.
+ */
+function let_travel_scripts() {
+    $theme_version = LET_TRAVEL_VERSION;
+
+    wp_enqueue_style( 'let-travel-style', get_stylesheet_uri(), array(), $theme_version );
+    wp_enqueue_style( 'let-travel-main', get_template_directory_uri() . '/assets/css/main.css', array( 'let-travel-style' ), $theme_version );
+
+    wp_enqueue_script( 'let-travel-main', get_template_directory_uri() . '/assets/js/main.js', array( 'jquery' ), $theme_version, true );
+}
+add_action( 'wp_enqueue_scripts', 'let_travel_scripts' );
+
+/**
+ * Register widget area.
+ */
+function let_travel_widgets_init() {
+    register_sidebar(
+        array(
+            'name'          => __( 'Footer Newsletter', 'let-travel' ),
+            'id'            => 'footer-newsletter',
+            'before_widget' => '<div id="%1$s" class="widget %2$s">',
+            'after_widget'  => '</div>',
+            'before_title'  => '<h4 class="widget__title">',
+            'after_title'   => '</h4>',
+        )
+    );
+}
+add_action( 'widgets_init', 'let_travel_widgets_init' );
+
+/**
+ * Include template tags and helpers.
+ */
+require get_template_directory() . '/inc/template-tags.php';
+require get_template_directory() . '/inc/customizer.php';

--- a/wp-content/themes/let-travel/header.php
+++ b/wp-content/themes/let-travel/header.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Header template
+ *
+ * @package Let_Travel
+ */
+?><!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
+<meta charset="<?php bloginfo( 'charset' ); ?>" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<?php wp_head(); ?>
+</head>
+<body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
+<div class="site-wrapper">
+    <header class="site-header">
+        <div class="container site-header__inner">
+            <div class="site-branding">
+                <?php if ( has_custom_logo() ) : ?>
+                    <?php the_custom_logo(); ?>
+                <?php else : ?>
+                    <a class="site-logo" href="<?php echo esc_url( home_url( '/' ) ); ?>">
+                        <?php bloginfo( 'name' ); ?>
+                    </a>
+                <?php endif; ?>
+            </div>
+            <nav class="main-navigation" aria-label="<?php esc_attr_e( 'Primary navigation', 'let-travel' ); ?>">
+                <?php
+                wp_nav_menu(
+                    array(
+                        'theme_location' => 'primary',
+                        'menu_class'     => 'menu-items',
+                        'container'      => false,
+                        'fallback_cb'    => '__return_false',
+                    )
+                );
+                ?>
+            </nav>
+            <div class="site-header__cta">
+                <a class="btn btn--primary" href="<?php echo esc_url( home_url( '/contact' ) ); ?>">
+                    <?php esc_html_e( 'Book Now', 'let-travel' ); ?>
+                </a>
+            </div>
+        </div>
+    </header>
+    <main id="primary" class="site-main">

--- a/wp-content/themes/let-travel/inc/customizer.php
+++ b/wp-content/themes/let-travel/inc/customizer.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Customizer additions.
+ *
+ * @package Let_Travel
+ */
+
+/**
+ * Register customizer settings for theme sections.
+ */
+function let_travel_customize_register( $wp_customize ) {
+    $wp_customize->add_section(
+        'let_travel_cta_section',
+        array(
+            'title'       => __( 'Call To Action', 'let-travel' ),
+            'description' => __( 'Update the call to action content displayed near the footer.', 'let-travel' ),
+            'priority'    => 160,
+        )
+    );
+
+    $wp_customize->add_setting(
+        'let_travel_cta_title',
+        array(
+            'default'           => __( 'Ready for your next adventure?', 'let-travel' ),
+            'sanitize_callback' => 'sanitize_text_field',
+        )
+    );
+
+    $wp_customize->add_control(
+        'let_travel_cta_title',
+        array(
+            'label'   => __( 'CTA Title', 'let-travel' ),
+            'section' => 'let_travel_cta_section',
+            'type'    => 'text',
+        )
+    );
+
+    $wp_customize->add_setting(
+        'let_travel_cta_description',
+        array(
+            'default'           => __( 'Join thousands of travelers exploring the world with Let Travel.', 'let-travel' ),
+            'sanitize_callback' => 'wp_kses_post',
+        )
+    );
+
+    $wp_customize->add_control(
+        'let_travel_cta_description',
+        array(
+            'label'   => __( 'CTA Description', 'let-travel' ),
+            'section' => 'let_travel_cta_section',
+            'type'    => 'textarea',
+        )
+    );
+
+    $wp_customize->add_setting(
+        'let_travel_cta_button_text',
+        array(
+            'default'           => __( 'Plan a Trip', 'let-travel' ),
+            'sanitize_callback' => 'sanitize_text_field',
+        )
+    );
+
+    $wp_customize->add_control(
+        'let_travel_cta_button_text',
+        array(
+            'label'   => __( 'CTA Button Text', 'let-travel' ),
+            'section' => 'let_travel_cta_section',
+            'type'    => 'text',
+        )
+    );
+
+    $wp_customize->add_setting(
+        'let_travel_cta_button_url',
+        array(
+            'default'           => home_url( '/contact' ),
+            'sanitize_callback' => 'esc_url_raw',
+        )
+    );
+
+    $wp_customize->add_control(
+        'let_travel_cta_button_url',
+        array(
+            'label'   => __( 'CTA Button URL', 'let-travel' ),
+            'section' => 'let_travel_cta_section',
+            'type'    => 'url',
+        )
+    );
+}
+add_action( 'customize_register', 'let_travel_customize_register' );

--- a/wp-content/themes/let-travel/inc/template-tags.php
+++ b/wp-content/themes/let-travel/inc/template-tags.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Template tags for Let Travel theme.
+ *
+ * @package Let_Travel
+ */
+
+if ( ! function_exists( 'let_travel_posted_on' ) ) {
+    /**
+     * Prints HTML with meta information for the current post-date/time.
+     */
+    function let_travel_posted_on() {
+        $time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
+
+        if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) {
+            $time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time>';
+        }
+
+        $time_string = sprintf(
+            $time_string,
+            esc_attr( get_the_date( DATE_W3C ) ),
+            esc_html( get_the_date() )
+        );
+
+        $posted_on = sprintf(
+            /* translators: %s: post date */
+            __( 'Posted on %s', 'let-travel' ),
+            '<a href="' . esc_url( get_permalink() ) . '" rel="bookmark">' . $time_string . '</a>'
+        );
+
+        echo '<span class="posted-on">' . $posted_on . '</span>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+    }
+}
+
+if ( ! function_exists( 'let_travel_posted_by' ) ) {
+    /**
+     * Prints HTML with meta information about theme author.
+     */
+    function let_travel_posted_by() {
+        $byline = sprintf(
+            /* translators: %s: post author */
+            __( 'by %s', 'let-travel' ),
+            '<span class="author vcard"><a class="url fn n" href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '">' . esc_html( get_the_author() ) . '</a></span>'
+        );
+
+        echo '<span class="byline"> ' . $byline . '</span>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+    }
+}

--- a/wp-content/themes/let-travel/index.php
+++ b/wp-content/themes/let-travel/index.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Default template
+ *
+ * @package Let_Travel
+ */
+
+get_header();
+?>
+<div class="container section">
+    <?php if ( have_posts() ) : ?>
+        <?php while ( have_posts() ) : the_post(); ?>
+            <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+                <header class="entry-header">
+                    <?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
+                </header>
+                <div class="entry-content">
+                    <?php the_content(); ?>
+                </div>
+            </article>
+        <?php endwhile; ?>
+        <?php the_posts_navigation(); ?>
+    <?php else : ?>
+        <p><?php esc_html_e( 'Sorry, no posts matched your criteria.', 'let-travel' ); ?></p>
+    <?php endif; ?>
+</div>
+<?php
+get_footer();

--- a/wp-content/themes/let-travel/page.php
+++ b/wp-content/themes/let-travel/page.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * The template for displaying all pages.
+ *
+ * @package Let_Travel
+ */
+
+get_header();
+?>
+<div class="container section">
+    <?php while ( have_posts() ) : the_post(); ?>
+        <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+            <header class="entry-header">
+                <?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
+            </header>
+            <div class="entry-content">
+                <?php
+                the_content();
+                wp_link_pages(
+                    array(
+                        'before' => '<div class="page-links">' . esc_html__( 'Pages:', 'let-travel' ),
+                        'after'  => '</div>',
+                    )
+                );
+                ?>
+            </div>
+        </article>
+    <?php endwhile; ?>
+</div>
+<?php
+get_footer();

--- a/wp-content/themes/let-travel/style.css
+++ b/wp-content/themes/let-travel/style.css
@@ -1,0 +1,578 @@
+/*
+Theme Name: Let Travel
+Theme URI: https://let-travel-128.webflow.io/home-1
+Author: OpenAI Assistant
+Author URI: https://openai.com/
+Description: A conversion of the Let Travel Webflow landing page into a responsive WordPress theme.
+Version: 1.0.0
+License: GNU General Public License v2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: let-travel
+Tags: custom-background, custom-logo, custom-menu, featured-images, full-width-template
+*/
+
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&family=Playfair+Display:wght@500;600;700&display=swap');
+
+:root {
+  --color-primary: #2f80ed;
+  --color-primary-dark: #1c5db3;
+  --color-accent: #f2994a;
+  --color-dark: #1b1b1d;
+  --color-muted: #6b7280;
+  --color-light: #f7f8fa;
+  --font-body: 'Poppins', sans-serif;
+  --font-display: 'Playfair Display', serif;
+  --container-width: min(1100px, 90vw);
+  --shadow-card: 0 15px 35px rgba(23, 32, 90, 0.12);
+}
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-body);
+  color: var(--color-dark);
+  background-color: #fff;
+  line-height: 1.6;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+  height: auto;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.site-wrapper {
+  overflow: hidden;
+}
+
+.container {
+  width: 100%;
+  margin: 0 auto;
+  max-width: var(--container-width);
+}
+
+.section {
+  padding: 6rem 0;
+}
+
+.section.section--light {
+  background: var(--color-light);
+}
+
+.section.section--overlay {
+  position: relative;
+  background: linear-gradient(135deg, rgba(47, 128, 237, 0.9), rgba(242, 153, 74, 0.9));
+  color: #fff;
+}
+
+.section.section--overlay::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: url('https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1400&q=80') center/cover;
+  opacity: 0.15;
+  z-index: 0;
+}
+
+.section__title {
+  font-size: clamp(2.25rem, 4vw, 3rem);
+  margin: 0 0 1rem;
+  font-family: var(--font-display);
+}
+
+.section__subtitle {
+  color: var(--color-muted);
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-weight: 600;
+}
+
+.section__text {
+  max-width: 640px;
+  margin-bottom: 2.5rem;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.85rem 2.2rem;
+  border-radius: 999px;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.btn.btn--primary {
+  background: var(--color-primary);
+  color: #fff;
+  box-shadow: 0 12px 25px rgba(47, 128, 237, 0.3);
+}
+
+.btn.btn--primary:hover,
+.btn.btn--primary:focus {
+  background: var(--color-primary-dark);
+  transform: translateY(-2px);
+}
+
+.btn.btn--ghost {
+  background: transparent;
+  color: #fff;
+  border: 1.5px solid rgba(255, 255, 255, 0.65);
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  backdrop-filter: blur(16px);
+  background: rgba(255, 255, 255, 0.8);
+  border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.site-header__inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem 0;
+}
+
+.site-logo {
+  font-family: var(--font-display);
+  font-size: 1.75rem;
+  font-weight: 600;
+  color: var(--color-primary);
+}
+
+.main-navigation {
+  display: flex;
+  gap: 2rem;
+  align-items: center;
+}
+
+.main-navigation a {
+  color: var(--color-dark);
+  font-weight: 500;
+  font-size: 0.95rem;
+  position: relative;
+}
+
+.main-navigation a::after {
+  content: '';
+  position: absolute;
+  bottom: -6px;
+  left: 0;
+  width: 0;
+  height: 2px;
+  background: var(--color-primary);
+  transition: width 0.3s ease;
+}
+
+.main-navigation a:hover::after,
+.main-navigation .current-menu-item > a::after {
+  width: 100%;
+}
+
+.hero {
+  padding: 8rem 0 6rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 3rem;
+  align-items: center;
+}
+
+.hero__heading {
+  font-size: clamp(2.75rem, 5vw, 3.75rem);
+  line-height: 1.1;
+  font-family: var(--font-display);
+  margin-bottom: 1.5rem;
+}
+
+.hero__tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1.2rem;
+  border-radius: 999px;
+  background: rgba(47, 128, 237, 0.12);
+  color: var(--color-primary);
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+}
+
+.hero__copy {
+  color: var(--color-muted);
+  font-size: 1.05rem;
+}
+
+.hero__meta {
+  margin-top: 2rem;
+  display: flex;
+  gap: 2.5rem;
+  flex-wrap: wrap;
+}
+
+.hero__stat {
+  display: flex;
+  flex-direction: column;
+}
+
+.hero__stat span:first-child {
+  font-size: 2.5rem;
+  font-weight: 600;
+  color: var(--color-primary);
+}
+
+.hero__visual {
+  position: relative;
+}
+
+.hero__card {
+  position: absolute;
+  right: -5%;
+  bottom: 12%;
+  background: #fff;
+  padding: 1.75rem;
+  border-radius: 20px;
+  box-shadow: var(--shadow-card);
+  width: min(280px, 80%);
+}
+
+.hero__card h4 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.hero__card ul {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.hero__card li {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.9rem;
+  color: var(--color-muted);
+}
+
+.destinations {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.75rem;
+}
+
+.destination-card {
+  position: relative;
+  border-radius: 22px;
+  overflow: hidden;
+  min-height: 260px;
+  box-shadow: var(--shadow-card);
+  isolation: isolate;
+}
+
+.destination-card img {
+  height: 100%;
+  width: 100%;
+  object-fit: cover;
+}
+
+.destination-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(17, 25, 40, 0) 25%, rgba(15, 23, 42, 0.75) 100%);
+  z-index: 1;
+}
+
+.destination-card__label {
+  position: absolute;
+  left: 1.5rem;
+  bottom: 1.5rem;
+  z-index: 2;
+  color: #fff;
+}
+
+.destination-card__label span:first-child {
+  display: block;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+}
+
+.destination-card__label strong {
+  font-size: 1.3rem;
+}
+
+.features {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 2rem;
+}
+
+.feature {
+  padding: 2.4rem 2rem;
+  border-radius: 18px;
+  background: #fff;
+  box-shadow: var(--shadow-card);
+  display: grid;
+  gap: 1.2rem;
+}
+
+.feature__icon {
+  width: 48px;
+  height: 48px;
+  border-radius: 12px;
+  background: rgba(47, 128, 237, 0.12);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-primary);
+  font-size: 1.5rem;
+}
+
+.feature__title {
+  font-size: 1.2rem;
+  margin: 0;
+}
+
+.feature__text {
+  color: var(--color-muted);
+  margin: 0;
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 2rem;
+}
+
+.stat-card {
+  padding: 2rem;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  text-align: center;
+}
+
+.stat-card strong {
+  display: block;
+  font-size: 2.4rem;
+  font-weight: 600;
+}
+
+.testimonials {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+}
+
+.testimonial {
+  padding: 2rem;
+  border-radius: 18px;
+  background: #fff;
+  box-shadow: var(--shadow-card);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.testimonial__meta {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.testimonial__meta img {
+  width: 54px;
+  height: 54px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.testimonial__name {
+  font-weight: 600;
+}
+
+.blog-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+}
+
+.blog-card {
+  border-radius: 18px;
+  overflow: hidden;
+  box-shadow: var(--shadow-card);
+  background: #fff;
+  display: grid;
+  grid-template-rows: 200px auto;
+}
+
+.blog-card__body {
+  padding: 1.75rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.blog-card__meta {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--color-primary);
+}
+
+.blog-card__title {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.cta {
+  border-radius: 28px;
+  background: linear-gradient(135deg, rgba(47, 128, 237, 0.92), rgba(242, 153, 74, 0.92));
+  padding: clamp(3rem, 5vw, 4rem);
+  color: #fff;
+  display: grid;
+  gap: 1.5rem;
+  text-align: center;
+  box-shadow: var(--shadow-card);
+}
+
+.cta__title {
+  font-size: clamp(2rem, 4vw, 2.75rem);
+  margin: 0;
+  font-family: var(--font-display);
+}
+
+.site-footer {
+  padding: 4rem 0;
+  background: #101522;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.site-footer__top {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 2.5rem;
+  align-items: start;
+}
+
+.site-footer__brand {
+  display: grid;
+  gap: 1rem;
+}
+
+.site-footer__brand .site-logo {
+  color: #fff;
+  font-size: 1.65rem;
+}
+
+.site-footer__menus {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1.75rem;
+}
+
+.site-footer__menus h4 {
+  margin: 0 0 0.85rem;
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.site-footer__menus ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.site-footer__bottom {
+  margin-top: 3rem;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.site-footer__socials {
+  display: flex;
+  gap: 1rem;
+}
+
+.site-footer__socials a {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+@media (max-width: 720px) {
+  .site-header__inner {
+    flex-wrap: wrap;
+    gap: 1.5rem;
+  }
+
+  .main-navigation {
+    width: 100%;
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+
+  .hero {
+    padding-top: 6rem;
+  }
+
+  .hero__visual::after {
+    display: none;
+  }
+
+  .hero__card {
+    position: static;
+    margin-top: 2rem;
+    width: 100%;
+  }
+
+  .site-footer__bottom {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
+.wp-block-button__link {
+  background: var(--color-primary);
+  border-radius: 999px;
+  padding: 0.75rem 1.6rem;
+  box-shadow: 0 10px 20px rgba(47, 128, 237, 0.25);
+}
+
+.alignwide {
+  margin-left: max(5vw, calc((100% - var(--container-width)) / 2));
+  margin-right: max(5vw, calc((100% - var(--container-width)) / 2));
+}
+
+.alignfull {
+  width: 100vw;
+  margin-left: calc(50% - 50vw);
+  margin-right: calc(50% - 50vw);
+}


### PR DESCRIPTION
## Summary
- port the Let Travel Webflow layout into a WordPress theme with hero, destination, story, and CTA sections
- add templates for front page, pages, and index plus reusable template tags and customizer options
- include responsive styling, scripts, and documentation for theme activation

## Testing
- `find wp-content/themes/let-travel -name '*.php' -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68ded8ef752083298d126287650eb01c